### PR TITLE
fix: return empty string instead of empty array if no footer content …

### DIFF
--- a/Configuration/TypoScript/Configuration/InitialDataConfiguration.typoscript
+++ b/Configuration/TypoScript/Configuration/InitialDataConfiguration.typoscript
@@ -25,7 +25,6 @@ initialData {
                     max = 1
                 }
                 slide = -1
-                stdWrap.ifEmpty.cObject = JSON
             }
         }
     }


### PR DESCRIPTION
…is found